### PR TITLE
Replace datadog/squid with ubuntu/squid

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - squid
 
   squid:
-    image: datadog/squid
+    image: ubuntu/squid
     networks:
       - frontend
     ports:


### PR DESCRIPTION
Replace datadog/squid with ubuntu/squid Docker image since `datadog/squid` Docker image which has now been deleted.